### PR TITLE
[codex] Polish fr-FR Movie Master locale

### DIFF
--- a/locale/fr-FR/dialog/fallback.api.dialog
+++ b/locale/fr-FR/dialog/fallback.api.dialog
@@ -1,1 +1,1 @@
-Je reviens à l'API par défaut.
+Je reviens à l'A P I par défaut.

--- a/locale/fr-FR/dialog/genre.movie.search.dialog
+++ b/locale/fr-FR/dialog/genre.movie.search.dialog
@@ -1,1 +1,1 @@
-Voici des films du genre {genre} :
+Voici des films du genre {genre}.

--- a/locale/fr-FR/dialog/genre.tv.search.dialog
+++ b/locale/fr-FR/dialog/genre.tv.search.dialog
@@ -1,1 +1,1 @@
-Voici des émissions télé du genre {genre} :
+Voici des séries du genre {genre}.

--- a/locale/fr-FR/dialog/movie.description.error.dialog
+++ b/locale/fr-FR/dialog/movie.description.error.dialog
@@ -1,2 +1,1 @@
-Je ne trouve pas de synopsis pour le film {movie}.
 Je n'arrive pas à trouver de résumé pour le film {movie}.

--- a/locale/fr-FR/dialog/movie.year.error.dialog
+++ b/locale/fr-FR/dialog/movie.year.error.dialog
@@ -1,2 +1,1 @@
-Je ne trouve pas la date de sortie du film {movie}.
 Je ne connais pas l'année de sortie du film {movie}.

--- a/locale/fr-FR/dialog/no.api.dialog
+++ b/locale/fr-FR/dialog/no.api.dialog
@@ -1,1 +1,1 @@
-Vous devez renseigner votre clé API TMDB sur home point mycroft point ai pour utiliser Movie Master.
+Vous devez renseigner votre clé A P I T M D B sur home point mycroft point A I pour utiliser Movie Master.

--- a/locale/fr-FR/dialog/no.valid.api.dialog
+++ b/locale/fr-FR/dialog/no.valid.api.dialog
@@ -1,1 +1,1 @@
-La clé API que vous avez saisie n'est pas valide. Consultez le fichier README pour savoir comment en obtenir une.
+La clé A P I que vous avez saisie n'est pas valide. Consultez le fichier lisez-moi pour savoir comment en obtenir une.

--- a/locale/fr-FR/vocab/genre.tv.search.intent
+++ b/locale/fr-FR/vocab/genre.tv.search.intent
@@ -1,2 +1,2 @@
-quelles sont les émissions télé du genre {genre}
-trouve-moi des émissions télé du genre {genre}
+quelles séries sont du genre {genre}
+trouve-moi des séries du genre {genre}

--- a/locale/fr-FR/vocab/movie.genre.search.intent
+++ b/locale/fr-FR/vocab/movie.genre.search.intent
@@ -1,0 +1,2 @@
+cherche des films de type {genre}
+propose-moi des films de genre {genre}

--- a/locale/fr-FR/vocab/movie.top.intent
+++ b/locale/fr-FR/vocab/movie.top.intent
@@ -1,2 +1,1 @@
-liste les films les mieux notés du moment
 quels sont les films les mieux notés du moment

--- a/locale/fr-FR/vocab/movie.year.intent
+++ b/locale/fr-FR/vocab/movie.year.intent
@@ -1,2 +1,1 @@
-en quelle année le film {movie} est-il sorti
-quand le film {movie} est-il sorti
+(en quelle année|quand) le film {movie} est-il sorti


### PR DESCRIPTION
## Summary
- Split PR #61 back to locale-only: the runtime genre-search handlers from the original diff are already on `dev` via PR #55.
- Polish fr-FR Movie Master dialogs and intents for more natural voice-assistant interaction.
- Keep spoken acronyms as `A P I` and add the missing movie genre search locale resource.

## Validation
- Resource parity check against en-US for fr-FR locale files
- Placeholder preservation scan
- Raw `API` scan for fr-FR dialog/intent files
- `git diff --check origin/dev..HEAD`
- `python -m compileall -q __init__.py locale`

## CI Note
- The failing Build/Coverage/Ovoscope jobs fail before resource checks run. Pytest collection hits existing test dependency/import issues: `ModuleNotFoundError: No module named 'mock'` and `ModuleNotFoundError: No module named 'ovos_workshop.skills.base'`. Those are intentionally left out of this locale-only branch.
